### PR TITLE
Pin google-github-actions/setup-gcloud to v0 instead of master

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -44,17 +44,17 @@ jobs:
         python -m pytest -m "not integration"
         cd ..
 
-  deploy-crop-classification: 
+  deploy-crop-classification:
     runs-on: ubuntu-latest
     needs: test-crop-classification
     if: github.ref == 'refs/heads/main'
     steps:
     - uses: actions/checkout@v2
-    - uses: google-github-actions/setup-gcloud@master
+    - uses: google-github-actions/setup-gcloud@v0
       with:
         project_id: ${{ secrets.GCP_PROJECT_ID }}
         service_account_key: ${{ secrets.GCP_SA_KEY }}
-        export_default_credentials: true   
+        export_default_credentials: true
     - name: Deploy Docker inference image
       run: |
         gcloud auth configure-docker us-central1-docker.pkg.dev


### PR DESCRIPTION
See [here](https://github.com/nasaharvest/timl/runs/5726784424?check_suite_focus=true) for more information:

```
Warning: google-github-actions/setup-gcloud is pinned at "master". We strongly advise against pinning to "@master" as it may be unstable. Please update your GitHub Action YAML from:

    uses: 'google-github-actions/setup-gcloud@master'

to:

    uses: 'google-github-actions/setup-gcloud@v0'

Alternatively, you can pin to any git tag or git SHA in the repository.
Error: On 2022-04-05, the default branch will be renamed from "master" to "main". Your action is currently pinned to "@master". Even though GitHub creates redirects for renamed branches, testing found that this rename breaks existing GitHub Actions workflows that are pinned to the old branch name.

We strongly advise updating your GitHub Action YAML from:

    uses: 'google-github-actions/setup-gcloud@master'

to:

    uses: 'google-github-actions/setup-gcloud@v0'
```